### PR TITLE
Initialize Ceph connection during provider config

### DIFF
--- a/ceph/provider.go
+++ b/ceph/provider.go
@@ -60,5 +60,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		MonHost:    d.Get("mon_host").(string),
 	}
 
+	config.GetCephConnection()
 	return config, nil
 }


### PR DESCRIPTION
Fix a race condition when multiple resources call GetCephConnection() in parallel which can result in a misleading "rados: ret=-110, Connection timed out" error.